### PR TITLE
Griddocs onno

### DIFF
--- a/themes/sara/static/sara.css_t
+++ b/themes/sara/static/sara.css_t
@@ -304,6 +304,14 @@ table.highlighttable td {
     padding: 0;
 }
 
+table.docutils td, table.docutils th {
+    padding: 8px 8px 8px 8px !important;
+    border-top: 1px solid #aaa !important;
+    border-left: 1px solid #aaa !important;
+    border-right: 1px solid #aaa !important;
+    border-bottom: 1px solid #aaa !important;
+}
+
 a em.std-term {
    color: #007f00;
 }


### PR DESCRIPTION
I want all borders in tables to be visible, so that we can display
complex table structures, like cells that span multiple columns.