### PR TITLE
Adding style_guidelines page

### DIFF
--- a/source/Pages/documentation/style_guidelines.rst
+++ b/source/Pages/documentation/style_guidelines.rst
@@ -1,0 +1,12 @@
+.. toctree::
+   :hidden:
+   
+.. _doc-style:
+
+****************
+Style guidelines
+****************
+
+This page will give some style guidelines for the grid documentation.
+
+.. warning:: This page is still under construction.


### PR DESCRIPTION
Adding style_guidelines to stimulate a consistent style throughout the griddoc. We can discuss
what to put in it, perhaps in the Github 'issues' or in a meeting.