### PR TITLE
Griddocs restyling

### DIFF
--- a/source/Pages/Advanced/grid_job_requirements.rst
+++ b/source/Pages/Advanced/grid_job_requirements.rst
@@ -27,12 +27,12 @@ Job requirements are written as an optional statement in the JDL file::
 
   Requirements = <expression>;
 
-Job requirements follow the JDL syntax. This also means that you can have multiple requirements using boolean operators ``&&`` for
+Job requirements follow the :abbr:`JDL (job description language)` syntax. This also means that you can have multiple requirements using boolean operators ``&&`` for
 *requirement 1 AND requirement 2*, and ``||`` for *requirement 1 OR
 requirement 2*. You can also use parentheses ``(...)`` for an even more
 fine-grained control over requirements.
 
-.. seealso:: For detailed information about ``JDL`` attributes supported by the gLite Workload Management System, have a look in the `EGEE JDL guide`_.
+.. seealso:: For detailed information about :abbr:`JDL (job description language)` attributes supported by the gLite Workload Management System, have a look in the `EGEE JDL guide`_.
 
 
 ============
@@ -105,12 +105,12 @@ Synopsis::
     Requirements=(RegExp("gina", other.GlueCEUniqueID));
 
 With the ``other.GlueCEInfoHostName`` criterion you can specify on which
-compute element your jobs will be scheduled. Or even on which CE your
+compute element your jobs will be scheduled. Or even on which :abbr:`CE (compute element)` your
 jobs will *not* be scheduled. This is convenient in cases where you know
 jobs will fail on particular systems, for some reason.
 
-other.GlueCEInfoHostName contains the hostname, while other.GlueCEUniqueID contains the full CE endpoint name including
-the queue. You can lookup these with the command "lcg-infosites --vo lsgrid ce". The last field is the GlueCEUniqueID.
+``other.GlueCEInfoHostName`` contains the hostname, while ``other.GlueCEUniqueID`` contains the full :abbr:`CE (compute element)` endpoint name including
+the queue. You can lookup these with the command ``lcg-infosites --vo lsgrid ce``. The last field is the ``GlueCEUniqueID``.
 
 .. _req-multicore:   
    
@@ -125,9 +125,9 @@ Synopsis::
     SmpGranularity = 4;
     CPUNumber = 4;   
 	
-CPUNumber is the number of cores requested. SMPGranularity is the number of cores that must be scheduled on the same host.
+``CPUNumber`` is the number of cores requested. ``SMPGranularity`` is the number of cores that must be scheduled on the same host.
 
-Note that if you do not specify SmpGranularity the requested number of cores (CPUNumber) can be distributed over different nodes, which is only useful for MPI (or likewise) applications. 
+Note that if you do not specify ``SmpGranularity`` the requested number of cores (``CPUNumber``) can be distributed over different nodes, which is only useful for MPI (or likewise) applications.
 
 .. warning:: If you are running a multi-core process in your job, and
              you do not set the correct number of CPU cores, **you will 
@@ -151,15 +151,11 @@ Synopsis::
     CPUNumber = 4;
     SMPGranularity = 4;
 
-The default is to select a cluster with GlueHostArchitectureSMPSize >= SmpGranularity.
+The default is to select a cluster with ``GlueHostArchitectureSMPSize >= SmpGranularity``.
 For efficient job allocation on a cluster it is often better to request a number of cores which is less
-than the GlueHostArchitectureSMPSize (i.e. the number of cores per node).
+than the ``GlueHostArchitectureSMPSize`` (i.e. the number of cores per node).
 
 
-
-..
-
-..
 
 .. Links:
 

--- a/source/Pages/Advanced/grid_software.rst
+++ b/source/Pages/Advanced/grid_software.rst
@@ -17,7 +17,7 @@ In this page we will talk about the options to run your software on the Grid wor
 Softdrive 
 =========
 
-``Softdrive`` is the service that allows you to install software in a central place and distribute it *automagically* on the Grid. You install the software once, and it will be available on all clusters, to all users. This means that you no longer need to supply your software in your *input sandbox*, or download your software in your job.
+Softdrive is the service that allows you to install software in a central place and distribute it *automagically* on the Grid. You install the software once, and it will be available on all clusters, to all users. This means that you no longer need to supply your software in your *input sandbox*, or download your software in your job.
 
 
 .. _cvmfs:
@@ -25,7 +25,7 @@ Softdrive
 CVMFS
 =====
 
-Softdrive is using the ``CVMFS`` (short for CernVM File System) tool on the background. CVMS is a network file system based on HTTP and optimized to deliver experiment software in a fast, scalable, and reliable way. 
+Softdrive is using the CVMFS (short for CernVM File System) tool on the background. CVMFS is a network file system based on HTTP and optimized to deliver experiment software in a fast, scalable, and reliable way. 
 
 
 Quickstart
@@ -101,7 +101,7 @@ Login to your :ref:`UI account <get-ui-account>` and check whether your files ar
     # drwxr-xr-x 17 cvmfs cvmfs 4096 Dec 16 12:11 test_dir
     
 
-.. note:: If your software is statically compiled, then copying the executables from your home directory to ``/cvmfs/softdrive.nl/$USER/`` should work. Just remember to export the ``/cvmfs/softdrive.nl/$USER`` software paths into your Grid scripts or UI bashrc. In other cases with library path dependencies, we advice you to install your software directly under ``/cvmfs/softdrive.nl/$USER`` or use a ``prefix``. An example of software installation in Softdrive can be found in section :ref:`anaconda on Grid <softdrive-anaconda>`.
+.. note:: If your software is statically compiled, then copying the executables from your home directory to ``/cvmfs/softdrive.nl/$USER/`` should work. Just remember to export the ``/cvmfs/softdrive.nl/$USER`` software paths into your Grid scripts or UI bashrc. In other cases with library path dependencies, we advice you to install your software directly under ``/cvmfs/softdrive.nl/$USER`` or use a prefix. An example of software installation in Softdrive can be found in section :ref:`anaconda on Grid <softdrive-anaconda>`.
   
   
 .. _python-grid:
@@ -137,7 +137,7 @@ Softdrive anaconda
 
     bash Anaconda2-2.4.0-Linux-x86_64.sh
 
-Note here! The installer will ask you to which location to install the software. Do not accept the default but change it to: **/cvmfs/softdrive.nl/$USER/anaconda-2-2.4.0/**:
+Note here! The installer will ask you to which location to install the software. Do not accept the default but change it to: ``/cvmfs/softdrive.nl/$USER/anaconda-2-2.4.0/``:
 
 .. code-block:: bash  
     
@@ -174,9 +174,7 @@ Docker
 
 At the moment it is not possible to run Docker containers on the :ref:`dutch-grid` or :ref:`lsg`. We are currently investigating different possibilities. Please contact us at helpdesk@surfsara.nl to discuss about the available options.
 
-..
 
-..
 
 .. Links:
 

--- a/source/Pages/Advanced/grid_storage.rst
+++ b/source/Pages/Advanced/grid_storage.rst
@@ -128,7 +128,7 @@ Logical File Name (LFN) and Grid Unique Identifier (GUID)
 These identifiers correspond to logical filename such as ``lfn:/grid/lsgrid/homer/zap.tar``
 
 
-.. note:: The SURLs and TURLs contain information about where a ``physical`` file is located. While the GUIDs and LFNs identify a ``logical`` filename irrespective of its location. You only need to use these if you work with :ref:`large-data-lfc-practice` on multiple LSG sites.
+.. note:: The SURLs and TURLs contain information about where a **physical** file is located. In contrast, the GUIDs and LFNs identify a **logical** filename irrespective of its location. You only need to use these if you work with :ref:`large-data-lfc-practice` on multiple LSG sites.
 
 
 .. _storage-ports:
@@ -329,7 +329,7 @@ Once you submit your stage requests, you can use the gfal scripts to monitor the
 Unpin a file
 ============
 
-Your files may remain ``ONLINE`` as long as there is free space on the disk pools. When a pool group is full and free space is needed, dCache will purge the least recently used cached files. The tape replica will remain on tape.
+Your files may remain *online* as long as there is free space on the disk pools. When a pool group is full and free space is needed, dCache will purge the least recently used cached files. The tape replica will remain on tape.
 
 The disk pool where your files are staged has limited capacity and is only meant for data that a user wants to process on a Grid site. When you :ref:`pin a file <pin-file>` you set a `pin lifetime`. The file will not be purged until the pin lifetime has expired. Then the data may be purged from disk, as soon as the space is required for new stage requests. When the disk copy has been purged, it has to be staged again in order to be processed on a Worker Node.
 

--- a/source/Pages/Advanced/storage_clients/fts.rst
+++ b/source/Pages/Advanced/storage_clients/fts.rst
@@ -4,7 +4,7 @@
 *fts* client
 ************
 
-This page includes the basic commands to use ``fts``. For an overview of storage clients, see :ref:`storage-clients`.
+This page includes the basic commands to use the FTS (file transfer service). For an overview of storage clients, see :ref:`storage-clients`.
 
 .. contents:: 
     :depth: 4
@@ -14,7 +14,7 @@ This page includes the basic commands to use ``fts``. For an overview of storage
 FTS
 ===
 
-`FTS3`_ is a file transfer service for reliable file transfers across sites or else, ``third party`` transfers. You cannot use it to transfer files from your local machine to dCache and vice-versa. FTS3 service has been running for years. It was developed by Cern for WLCG data transfers up to petabytes per month.
+`FTS3`_ is a file transfer service for reliable file transfers across sites or else, *third party* transfers. You cannot use it to transfer files from your local machine to dCache and vice-versa. FTS3 service has been running for years. It was developed by Cern for WLCG data transfers up to petabytes per month.
 
 From the user perspective, it allows data movement, retrying if necessary, monitoring and displaying usage statistics, see `FTS3 wiki`_. From the operations view, it optimises resource usage. 
 
@@ -35,7 +35,7 @@ FTS file transfers
 
 fts-transfer-submit
 -------------------
-This command submits transfer-jobs by specifying the source and destination file location. The file location can be a ``SURL`` or ``TURL`` or ``https`` link. The source and destination endpoints are ``griftp`` or ``srm servers``. The output of the command is a *unique ID* that can be used for tracing the transfer status.
+This command submits transfer-jobs by specifying the source and destination file location. The file location can be a SURL, TURL or https link. The source and destination endpoints are GridFTP or SRM servers. The output of the command is a *unique ID* that can be used for tracing the transfer status.
 
 
 Basic options

--- a/source/Pages/Advanced/storage_clients/webdav.rst
+++ b/source/Pages/Advanced/storage_clients/webdav.rst
@@ -4,7 +4,7 @@
 *webdav* client
 ***************
 
-This page includes the basic commands to use ``webdav``. For an overview of storage clients, see :ref:`storage-clients`.
+This page includes the basic commands to use the webdav protocol. For an overview of storage clients, see :ref:`storage-clients`.
 
 .. contents:: 
     :depth: 4
@@ -39,7 +39,7 @@ If you don't know which one you should use, choose the first. It has a good load
 
 webdav.grid.sara.nl is a DNS round robin that will direct you to a (more or less) random host in a pool of webdav servers.
 
-.. note:: To run the examples below you need to have a UI (or ``CUA``) account that is configured within dCache and authorized to the data you want to access. Contact us if you need assistance with that.
+.. note:: To run the examples below you need to have a :abbr:`UI (user interface)` (or :abbr:`CUA (SURFsara's central user adminstration)`) account that is configured within dCache and authorized to the data you want to access. Contact us if you need assistance with that.
 
 
 Listing

--- a/source/Pages/Basics/first_grid_job.rst
+++ b/source/Pages/Basics/first_grid_job.rst
@@ -244,7 +244,7 @@ Retrieve the output
 The output consists of the files included in the ``OutputSandbox`` statement. You can
 retrieve the job output once it is successfully completed, in other words the
 job status has changed from ``RUNNING`` to ``DONE``. The files in the
-output sandbox can be downloaded for approx. one week after the job finishes.
+output sandbox can be downloaded for approximately one week after the job finishes.
 
 .. note:: 
         You can choose the output directory with the ``--dir`` option. If you do not use this option then the output will be copied under the UI ``/scratch`` directory with a name based on the ID of the job.  

--- a/source/Pages/Basics/first_grid_job.rst
+++ b/source/Pages/Basics/first_grid_job.rst
@@ -210,7 +210,7 @@ To check the current job status from the command line, apply the following comma
 
 	glite-wms-job-status -i jobIds
 
-* Finally, a third (optional) way to check the job status is within the web browser that :ref:`you installed your certificate <digicert_browser_install>`. In this browser open the jobID link:
+* Finally, a third (optional) way to check the job status is with the web browser in which :ref:`you installed your certificate <digicert_browser_install>`. In this browser open the jobID link:
 
 	https://wms2.grid.sara.nl:9000/JIVYfkMxtnRFWweGsx0XAA #replace with your jobID
 

--- a/source/Pages/Basics/first_grid_job.rst
+++ b/source/Pages/Basics/first_grid_job.rst
@@ -26,7 +26,7 @@ Grid job lifecycle
 	
 To run your application on the Grid you need to describe its requirements in a specific language called ``job description language`` (JDL). This is similar to the information that we need to specify when we run jobs using a batch scheduling system like :ref:`pbs`, although it is slightly more complex as we are now scheduling jobs across multiple sites.
 
-Except for the application requirements, you also need to specify in the JDL the content of the input/output ``sandboxes``. These sandboxes allow you to transfer data to or from the Grid. The input sandbox contains all the files that you want to send with your job to the worker node, like e.g. a script that you want executed. The output sandbox contains all the files that you want to have transferred back to the UI. 
+Except for the application requirements, you also need to specify in the JDL the content of the *input/output sandboxes*. These sandboxes allow you to transfer data to or from the Grid. The input sandbox contains all the files that you want to send with your job to the worker node, like e.g. a script that you want executed. The output sandbox contains all the files that you want to have transferred back to the UI. 
 
 .. note:: The amount of data that you can transfer using the sandboxes is very limited, in the order of a few megabytes (less than **100MB**). This means that you should normally limit the input sandbox to a few script files and the output sandbox to the stderr and stdout files.	
 
@@ -43,7 +43,7 @@ The following animations illustrate the Grid lifecycle as described above:
 StartGridSession
 ================
 
-Before submitting your first Grid job, you need to create a ``proxy`` from your certificate. This has a short lifetime and prevents you from passing along your personal certificate to the Grid. The job will keep a copy of your proxy and pass it along to the Worker Node.
+Before submitting your first Grid job, you need to create a *proxy* from your certificate. This has a short lifetime and prevents you from passing along your personal certificate to the Grid. The job will keep a copy of your proxy and pass it along to the Worker Node.
 
 This section will show you how to create a valid proxy:
 
@@ -81,9 +81,9 @@ This section will show you how to create a valid proxy:
 	
 .. note:: What does the startGridSession script actually do?
 
-	* It generates a ``local proxy`` (x509up_uXXX) in the UI ``/tmp/`` directory
-	* It uploads this proxy to ``Myproxy server``
-	* It ``delegates`` the proxy to the WMS with your user name as the delegation ID (DID)
+	* It generates a *local proxy* ``x509up_uXXX`` in the :abbr:`UI (User Interface)` ``/tmp/`` directory
+	* It uploads this proxy to Myproxy server
+	* It delegates the proxy to the WMS with your user name as the delegation ID (DID)
 	
 	If you want to know more, see the advanced section about :ref:`grid-authentication`.
 
@@ -114,7 +114,7 @@ To submit a Grid job you must describe this in a plain text file, called JDL. Op
 	StdError = "simple.err";
 	OutputSandbox = {"simple.out","simple.err"}; 
 
-This job involves no large input or output files. It will return to the user the hostname of the Worker Node that the job will land on. This is specified as the ``StdOutput`` file “simple.out” declared in the ``OutputSandbox`` statement.
+This job involves no large input or output files. It will return to the user the hostname of the Worker Node that the job will land on. This is specified as the ``StdOutput`` file ``simple.out`` declared in the ``OutputSandbox`` statement.
 
 
 .. _job-match:
@@ -196,7 +196,7 @@ The jobID string looks like this:
 Track the job status
 ====================
 
-To check the current job status from the command line, apply the following command that queries the ``WMS`` for the status of the job. 
+To check the current job status from the command line, apply the following command that queries the :abbr:`WMS (workload management system)` for the status of the job. 
 
 * After submitting the job, type:
 
@@ -294,7 +294,7 @@ Congratulations! You have just executed your first job to the Grid!
 
 Let's summarise what we've seen so far.
 
-You interact with the Grid via the UI machine ``ui.grid.sara.nl``. You describe each job in a ``JDL`` (Job Description Language) file where you list which program should be executed and what are the worker node requirements. From the UI, you create first a proxy of your Grid certificate and submit your job with ``glite-*`` commands. The resource broker, called ``WMS`` (short for Workload Management System), accepts your jobs, assigns them to the most appropriate ``CE`` (Computing Element), records the jobs statuses and retrieves the output. 
+You interact with the Grid via the UI machine ``ui.grid.sara.nl``. You describe each job in a JDL (Job Description Language) file where you list which program should be executed and what are the worker node requirements. From the :abbr:`UI (user interface)`, you create first a proxy of your Grid certificate and submit your job with ``glite-*`` commands. The resource broker, called WMS (short for Workload Management System), accepts your jobs, assigns them to the most appropriate CE (Computing Element), records the jobs statuses and retrieves the output. 
 
 This is a short overview of the commands needed to handle simple jobs: 
 

--- a/source/Pages/Basics/first_grid_job.rst
+++ b/source/Pages/Basics/first_grid_job.rst
@@ -265,9 +265,9 @@ where you should substitute jobIds with the file that you used to store the
 job ids.
 
 If you omitted the ``--dir`` option, your output stored on the
-``/scratch``-directory on the UI. Please remove your files from the
-``/scratch``-directory when they are no longer necessary. Also keep in
-mind that if the ``/scratch``-directory becomes too full, the
+``/scratch`` directory on the UI. Please remove your files from the
+``/scratch`` directory when they are no longer necessary. Also keep in
+mind that if the ``/scratch`` directory becomes too full, the
 administrators remove the older files until enough space is available
 again.
 

--- a/source/Pages/FAQ.rst
+++ b/source/Pages/FAQ.rst
@@ -240,7 +240,7 @@ How many cpu's, nodes does the Grid offer?
 The Grid infrastructure is interconnected clusters in Netherlands and abroad. The users can get access to multiple of these clusters based on their :ref:`Virtual Organisation <join-vo>`.
 
 * Global picture: 170 datacenters in 36 countries: in total more than 330000 compute cores, 500 PB disk, 500 PB tape.
-* In the Netherlands NGI_NL infrastructure: 14 datacenters (3 large Grid clusters, 11 smaller ones): in total approx 10000 compute cores, 12 PB disk, tape capacity up to 170 PB.
+* In the Netherlands NGI_NL infrastructure: 14 datacenters (3 large Grid clusters, 11 smaller ones): in total approximately 10000 compute cores, 12 PB disk, tape capacity up to 170 PB.
 
 
 .. _how-many-ch:

--- a/source/Pages/Practices/bootstrap.rst
+++ b/source/Pages/Practices/bootstrap.rst
@@ -94,7 +94,7 @@ Run on the Grid
 
      startGridSession lsgrid # replace lsgrid with your VO
 
-* Inspect the ``JDL`` file:
+* Inspect the JDL file:
 
   .. code-block:: bash
 
@@ -136,7 +136,7 @@ Once this jobs lands on the Grid, it will execute the ``wrapper.sh`` script whic
 
      glite-wms-job-status https://wms2.grid.sara.nl:9000/6swP5FEfGVZ69tVB3PwnDQ #replace with your jobID
   
-     #or
+     # or
      glite-wms-job-status -i jobIds
 
 * Once the job is finished, get the job output to the UI:


### PR DESCRIPTION
Further restyling to conform to style guidelines. Undone overly use of literals, adding :abbr: to acronyms.